### PR TITLE
added rpm configuration to provision script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.vagrant
+*~

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,20 +2,31 @@
 # vi: set ft=ruby :
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
+
+GLOBAL_REQUIRED_PLUGINS = %w(vagrant-hostsupdater)
+exit unless GLOBAL_REQUIRED_PLUGINS.all? do |plugin|
+  Vagrant.has_plugin?(plugin) || (
+  puts "The #{plugin} plugin is required. Please install it with:"
+  puts "$ vagrant plugin install #{plugin}"
+  false
+  )
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "bento/centos-6.8"
 
   #config.vbguest.auto_update = ture
   #config.vbguest.no_remote = false
 
-  #config.vm.provision :shell, path: "dev/bootstrap.sh"
+  config.vm.provision :shell, path: "scripts/setup.sh"
 
   config.ssh.shell = "sh"
   # avoid failures that may be mac-specific and/or version-specific
   config.ssh.insert_key = false
 
   ## create a private network visible only to the host machine
-  config.vm.network :private_network, ip: "192.168.99.110"
+  config.vm.hostname = "exchange.dev"
+  config.vm.network :private_network, ip: "192.168.99.161"
 
   ## assign a static ip visible to others on the network.
   # config.vm.network :public_network, :bridge => 'en0: Wi-Fi (AirPort)', ip: "192.168.10.222", netmask: "255.255.255.0"
@@ -23,10 +34,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Example of share an additional folder to the guest VM.
   # config.vm.synced_folder "../MapLoom", "/MapLoom"
-  config.vm.synced_folder "../django-fulcrum", "/django-fulcrum"
+#  config.vm.synced_folder "../django-fulcrum", "/django-fulcrum"
 
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "5096", "--cpus", "2"]
+    vb.customize ["modifyvm", :id, "--memory", "5012", "--cpus", "2"]
+    #vb.customize ["modifyvm", :id, "--memory", "8192", "--cpus", "4"]
   end
 end

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,70 @@
+sudo yum -y install https://s3.amazonaws.com/exchange-development-yum/exchange-development-repo-1.0.0.noarch.rpm
+sudo yum -y update
+sudo yum -y install exchange \
+                 boundless-postgis2_96 \
+                 elasticsearch \
+                 rabbitmq-server \
+                 erlang \
+                 geonode-geoserver \
+                 supervisor
+
+sed -i -e "s/export SITEURL=.*$/export SITEURL=\$\{SITEURL\:\-'http:\/\/$(hostname)\\/'\}/" /etc/profile.d/exchange-settings.sh
+grep DJANGO_SETTINGS_MODULE /etc/profile.d/exchange-settings.sh || \
+sed -i -e "s/set +e/export DJANGO_SETTINGS_MODULE=\$\{DJANGO_SETTINGS_MODULE\:\-'bex.settings'\}\nset +e/" /etc/profile.d/exchange-settings.sh
+
+sudo service postgresql-9.6 initdb
+
+sed -i -e "s/localhost/$(hostname)/" /etc/profile.d/exchange-settings.sh
+
+sudo chkconfig postgresql-9.6 on
+sudo sed -i.exchange 's/peer$/trust/g' /var/lib/pgsql/9.6/data/pg_hba.conf
+sudo sed -i.exchange 's/ident$/md5/g' /var/lib/pgsql/9.6/data/pg_hba.conf
+sudo service postgresql-9.6 restart
+
+sudo -u postgres psql -c "CREATE USER exchange WITH PASSWORD 'boundless';"
+sudo -u postgres psql -c "CREATE DATABASE exchange OWNER exchange;"
+sudo -u postgres psql -c "CREATE DATABASE exchange_data OWNER exchange;"
+sudo -u postgres psql -d exchange_data -c 'CREATE EXTENSION postgis;'
+sudo -u postgres psql -d exchange_data -c 'GRANT ALL ON geometry_columns TO PUBLIC;'
+sudo -u postgres psql -d exchange_data -c 'GRANT ALL ON spatial_ref_sys TO PUBLIC;'
+
+sudo chkconfig rabbitmq-server on
+sudo service rabbitmq-server start
+
+sudo chkconfig elasticsearch on
+sudo service elasticsearch start
+
+python - <<END
+from xml.etree import ElementTree
+import socket
+file_name = '/opt/geonode/geoserver_data/global.xml'
+tree = ElementTree.parse(file_name)
+root = tree.getroot()
+settings = tree.find("settings")
+proxyBaseUrl = settings.find("proxyBaseUrl")
+if proxyBaseUrl is None:
+    proxyBaseUrl = ElementTree.SubElement(settings, "proxyBaseUrl")
+proxyBaseUrl.text = "http://{0}/geoserver".format(socket.gethostname())
+tree.write(file_name)
+END
+
+python - <<END
+from xml.etree import ElementTree
+import socket
+file_name = '/opt/geonode/geoserver_data/security/role/geonode REST role service/config.xml'
+tree = ElementTree.parse(file_name)
+root = tree.getroot()
+baseUrl = tree.find("baseUrl")
+baseUrl.text = "http://{0}".format(socket.gethostname())
+tree.write(file_name)
+END
+
+sudo chkconfig tomcat8 on
+sudo service tomcat8 start
+
+sudo echo 'y' | exchange-config django
+sudo echo 'y' | exchange-config selinux
+sudo chkconfig exchange on
+sudo service exchange start
+sudo chkconfig httpd on
+sudo service httpd restart


### PR DESCRIPTION
This setup should automate the setup via a provision script, and alters the Vagrantfile.  This uses a plugin called hostsupdater. This allows a dev to do `vagrant up`, and the hostname provided in the vagrant file will automatically be added to the users hosts file.  This does require vagrant up to be ran as root.  After provisioning the user can then go to http://exchange.dev in a browser.  